### PR TITLE
getType respects also supertypes now

### DIFF
--- a/src/main/java/org/avaje/ebean/querybean/generator/ProcessingContext.java
+++ b/src/main/java/org/avaje/ebean/querybean/generator/ProcessingContext.java
@@ -143,10 +143,16 @@ public class ProcessingContext {
 
     TypeMirror typeMirror = field.asType();
 
-    PropertyType type = propertyTypeMap.getType(typeMirror.toString());
-    if (type != null) {
-      // simple scalar type
-      return type;
+    TypeMirror currentType = typeMirror;
+    while (currentType != null) {
+    	PropertyType type = propertyTypeMap.getType(currentType.toString());
+        if (type != null) {
+          // simple scalar type
+          return type;
+        }
+        // go up in class hierarchy
+        TypeElement fieldType = (TypeElement) typeUtils.asElement(currentType);
+        currentType = (fieldType == null) ? null : fieldType.getSuperclass();
     }
 
     if (dbJsonField(field)) {


### PR DESCRIPTION
Hello Rob, here is an enhancement from me.

Problem:
If you declare a more special datatype in your bean, no query property in your query-bean is generated.
E.g.: if you declare a "private GregorianCalendar date;" in your bean, no QBean.date is generated.
(of course, the query-bean generator does not know the type "GregorianCalendar")

for each custom/unknown type, no query-bean property is generated and as far as I understand, there is no way to extend the query-bean annotation processor to support additional custom types.

my fix goes up in the class hierarchy and generates a QBean.date for the super-class java.util.Calendar now. (which may not have all features for querying - but is sufficient in my use case)

Background
We use a modified version of GregorianCalendar (with special support for date-only/time-only - you cannot set a time in a date-only calendar for example) and own ScalarTypeConverters for converting java.sql.Date/Time/Timestamp to our Calendar implementation.

cheers
Roland
