### PR TITLE
Fix problem with long lines in manifest

### DIFF
--- a/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
+++ b/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
@@ -285,18 +285,23 @@ public class ProcessingContext {
 	
     FileObject resource = filer.createResource(location, "", META_INF + "/" + EBEAN_TYPEQUERY_MF);
 
-    Writer writer = resource.openWriter();
+    try (Writer writer = resource.openWriter()) {
+      writeManifest(writer, packages);
+    }
+  }
+
+  //Visible for testing
+  static void writeManifest(final Writer writer, Set<String> packages) throws IOException {
     writer.append("packages: ");
     int count = 0;
     for (String aPackage : packages) {
       if (count++ > 0) {
-        writer.append(",");
+        writer.append(",\n ");
       }
       writer.append(aPackage);
     }
 
     writer.append(NEWLINE).append(NEWLINE);
     writer.flush();
-    writer.close();
   }
 }

--- a/src/test/java/io/ebean/querybean/generator/ProcessingContextTest.java
+++ b/src/test/java/io/ebean/querybean/generator/ProcessingContextTest.java
@@ -1,0 +1,44 @@
+package io.ebean.querybean.generator;
+
+import static java.util.Arrays.asList;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.jar.Manifest;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ProcessingContextTest {
+
+  @Test
+  public void generate_and_read_lots_of_packages() throws IOException {
+    Set<String> packages = new LinkedHashSet<>();
+    for (int i = 0; i < 1000; i++) {
+      packages.add("com.example.i" + i);
+    }
+    manifestTester(packages);
+  }
+
+  @Test
+  public void generate_and_read_single_package() throws IOException {
+    Set<String> packages = Collections.singleton("com.example");
+    manifestTester(packages);
+  }
+
+  public void manifestTester(final Set<String> packages) throws IOException {
+    final StringWriter stringWriter = new StringWriter();
+    ProcessingContext.writeManifest(stringWriter, packages);
+    final Manifest manifest = new Manifest(new ByteArrayInputStream(stringWriter.toString().getBytes(StandardCharsets.UTF_8)));
+    final String[] manifestAttribute = manifest.getMainAttributes()
+                                               .getValue("packages")
+                                               .split(" *(,|;| ) *");
+    Assert.assertEquals(packages, asList(manifestAttribute));
+  }
+
+}


### PR DESCRIPTION
Before this patch, the manifest reading would blow up with "too long line"
if a lot of packages were to be enhanced. Java manifests are not allowed
to have any line longer than 72 characters as per
http://docs.oracle.com/javase/7/docs/technotes/guides/jar/jar.html