### PR TITLE
add originatingElement when writing QueryBean

### DIFF
--- a/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
+++ b/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
@@ -220,8 +220,8 @@ public class ProcessingContext {
   /**
    * Create a file writer for the given class name.
    */
-  public JavaFileObject createWriter(String factoryClassName) throws IOException {
-    return filer.createSourceFile(factoryClassName);
+  public JavaFileObject createWriter(String factoryClassName, Element originatingElement) throws IOException {
+    return filer.createSourceFile(factoryClassName, originatingElement);
   }
 
   /**

--- a/src/main/java/io/ebean/querybean/generator/SimpleQueryBeanWriter.java
+++ b/src/main/java/io/ebean/querybean/generator/SimpleQueryBeanWriter.java
@@ -330,7 +330,7 @@ class SimpleQueryBeanWriter {
 
   private Writer createFileWriter() throws IOException {
 
-    JavaFileObject jfo = processingContext.createWriter(destPackage + "." + "Q" + shortName);
+    JavaFileObject jfo = processingContext.createWriter(destPackage + "." + "Q" + shortName, element);
     return jfo.openWriter();
   }
 


### PR DESCRIPTION
this improves partial build as eclipse knows, which querybean depends on which entity-class