### PR TITLE
workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=544288

### DIFF
--- a/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
+++ b/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
@@ -183,6 +183,9 @@ class ProcessingContext {
     Element fieldType = typeUtils.asElement(typeMirror);
 
     if (fieldType != null) {
+      // workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=544288
+      fieldType = elementUtils.getTypeElement(fieldType.toString());
+      
       if (fieldType.getKind() == ElementKind.ENUM) {
         String fullType = typeDef(typeMirror);
         return new PropertyTypeEnum(fullType, Split.shortName(fullType));


### PR DESCRIPTION
Hello Rob, would you accept this workaround for the bug/different behaviour of the eclipse compiler

It prevents us to use the beanvalidation api 2.0 in conjunction with the annotation processor + eclipse
(java compiler will work)

Link to bug (not yet confirmed) https://bugs.eclipse.org/bugs/show_bug.cgi?id=544288
Link to sample project https://github.com/FOCONIS/ecj_bug_type_use_annotation

Cheers
Roland