### PR TITLE
Fix #34 get class full name through element

### DIFF
--- a/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
+++ b/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
@@ -155,20 +155,12 @@ class ProcessingContext {
    * Escape the type (e.g. java.lang.String) from the TypeMirror toString().
    */
   private static String typeDef(TypeMirror typeMirror) {
-    return typeDef(typeMirror.toString());
-  }
-
-  /**
-   * Escape the type (e.g. java.lang.String) from the TypeMirror toString().
-   */
-  static String typeDef(String typeDesc) {
-
-    int pos = typeDesc.lastIndexOf(" :: ");
-    if (pos > -1) {
-      // (@javax.validation.constraints.Size(min=1, max=10) :: java.lang.String)
-      typeDesc = typeDesc.substring(pos + 4, typeDesc.length() - 1);
+    if (typeMirror.getKind() == TypeKind.DECLARED) {
+      DeclaredType declaredType = (DeclaredType) typeMirror;
+      return declaredType.asElement().toString();
+    } else {
+      return typeMirror.toString();
     }
-    return typeDesc;
   }
 
   PropertyType getPropertyType(VariableElement field) {

--- a/src/test/java/io/ebean/querybean/generator/ProcessingContextTest.java
+++ b/src/test/java/io/ebean/querybean/generator/ProcessingContextTest.java
@@ -1,16 +1,4 @@
 package io.ebean.querybean.generator;
 
-
-import org.testng.annotations.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class ProcessingContextTest {
-
-	@Test
-	public void typeDefn() {
-
-		assertThat(ProcessingContext.typeDef("java.lang.String")).isEqualTo("java.lang.String");
-		assertThat(ProcessingContext.typeDef("(@javax.validation.constraints.Size(min=1, max=10) :: java.lang.String)")).isEqualTo("java.lang.String");
-	}
 }


### PR DESCRIPTION
Fix issue #34.

Get class full name through the `Element` class.